### PR TITLE
Allow greater config of issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,18 @@ jobs:
     runs-on: ubuntu-latest
     name: create maintenance issues
     steps:
+      # Assumes you want to supply your own csv from your destination repo.
+      # Check the tasks.csv file in this repo for required structure.
+      # If you want to use the tasks from this repo, no need to checkout and
+      # omit the path-to-data input below.
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: home_maintenance_action
         uses: maxbeizer/home_maintenance@main
         with:
           repo-nwo: 'maxbeizer/my-cool-repo'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-data: 'data/tasks.csv'
 ```
 
 ## Credit

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,17 @@ inputs:
   github-token:
     description: 'the github_token from the action'
     required: true
+  path-to-data:
+    description: 'the path to a csv of tasks'
+    required: false
+  time-frame:
+    description: 'seasonal or all tasks should be converted to issues'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.github-token }}
     - ${{ inputs.repo-nwo }}
+    - ${{ inputs.path-to-data }}
+    - ${{ inputs.time-frame }}

--- a/lib/home_maintenance.rb
+++ b/lib/home_maintenance.rb
@@ -11,6 +11,7 @@ require_relative './home_maintenance/time_framer'
 class HomeMaintenance
   class Error < StandardError; end
   DEFAULT_DATA_PATH = './data/tasks.csv'
+  ACCEPTABLE_TIME_FRAMES = %i[seasonal all].freeze
 
   def self.call(config = {})
     new(**config).call
@@ -23,8 +24,8 @@ class HomeMaintenance
     @logger = config[:logger]
 
     @repo_nwo = config[:repo_nwo]
-    @path_to_data = config[:path_to_data] || DEFAULT_DATA_PATH
-    @time_frame = config[:time_frame] || :seasonal
+    @path_to_data = massage_path_to_data(config)
+    @time_frame = (config[:time_frame] || :seasonal).to_sym
     @run_date = config[:run_date] || Date.today
     ensure_required_fields_set!
   end
@@ -33,14 +34,13 @@ class HomeMaintenance
     tasks = build_task_objects
     log "creating issues #{tasks.length} for: #{@repo_nwo}"
     tasks.map do |task|
-      res = @issue_client.create_issue(
+      @issue_client.create_issue(
         @repo_nwo,
         task.task_name,
         '**created by https://github.com/maxbeizer/home_maintenance**',
         labels: ['home_maintenance', task.area, task.task_type].join(',')
       )
 
-      log "result: #{res&.inpsect}"
       log "issue created: #{task.task_name}"
       task
     end
@@ -69,6 +69,7 @@ class HomeMaintenance
 
   def ensure_required_fields_set!
     raise Error, 'repo_nwo must be set!' if @issue_client.is_a?(Octokit::Client) && !@repo_nwo
+    raise Error, 'time_frame must be either seasonal or all' unless ACCEPTABLE_TIME_FRAMES.include?(@time_frame)
   end
 
   def log(msg)
@@ -76,6 +77,19 @@ class HomeMaintenance
 
     puts "#{Time.now.utc}: #{msg}"
   end
+
+  def massage_path_to_data(config = {})
+    return DEFAULT_DATA_PATH unless config[:path_to_data]
+
+    File.join(ENV['GITHUB_WORKSPACE'], config[:path_to_data])
+  end
 end
 
-HomeMaintenance.call(github_token: ARGV[0], repo_nwo: ARGV[1]) if $PROGRAM_NAME == __FILE__
+if $PROGRAM_NAME == __FILE__
+  HomeMaintenance.call(
+    github_token: ARGV[0],
+    repo_nwo: ARGV[1],
+    path_to_data: ARGV[2],
+    time_frame: ARGV[3]
+  )
+end

--- a/lib/home_maintenance/errors.rb
+++ b/lib/home_maintenance/errors.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Home to all custom exceptions
+class HomeMaintenance
+  class Error < StandardError; end
+
+  # When the input to the Action is invalid
+  class InvalidInputError < Error
+    def initialize(msg = 'Action config is invalid')
+      super
+    end
+  end
+
+  # When the calculated path to the CSV file cannot be found
+  class CSVReadError < Error
+    def initialize(msg = 'Unable to find CSV file of tasks')
+      super
+    end
+  end
+end

--- a/test/home_maintenance_test.rb
+++ b/test/home_maintenance_test.rb
@@ -25,6 +25,30 @@ class HomeMaintenanceTest < Minitest::Test
     assert_equal 'Clean AC condensor', result.task_name
   end
 
+  def test_it_errors_if_octokit_is_there_but_nwo_is_falsey
+    assert_raises HomeMaintenance::InvalidInputError, 'expected octokit + no repo_nwo to raise' do
+      subject_class.call(logger: noop)
+    end
+  end
+
+  def test_it_errors_if_octokit_is_there_but_nwo_is_empty
+    assert_raises HomeMaintenance::InvalidInputError, 'expected octokit + no repo_nwo to raise' do
+      subject_class.call(logger: noop, repo_nwo: '')
+    end
+  end
+
+  def test_it_errors_if_time_frame_is_invalid
+    assert_raises HomeMaintenance::InvalidInputError, 'expected octokit + no repo_nwo to raise' do
+      subject_class.call(time_frame: 'lololol', issue_client: MockIssueClient, logger: noop)
+    end
+  end
+
+  def test_it_errors_if_csv_does_not_exist
+    assert_raises HomeMaintenance::CSVReadError, 'expected raise with bad CSV path' do
+      subject_class.call(logger: noop, path_to_data: 'lol/wut.csv', repo_nwo: 'maxbeizer/home_maintenenace')
+    end
+  end
+
   private
 
   class MockIssueClient


### PR DESCRIPTION
Closes #2

This allows the user to pass in a path to data input. Being a bit lazy I made
some assumptions that the base path would be in the `GITHUB_WORKSPACE` variable.

This also allows one to pass in an undocumented input where one could have all
tasks created when the action runs, if one were so inclined... I don't know your
life. Just pass in `time_frame: all` in the config
